### PR TITLE
PatchPilot: remediate CVEs

### DIFF
--- a/.cursor/cli.json
+++ b/.cursor/cli.json
@@ -1,0 +1,28 @@
+{
+  "permissions": {
+    "allow": [
+      "Read(**)",
+      "Write(.patchpilot/output.json)",
+      "Shell(ls)",
+      "Shell(find)",
+      "Shell(rg)",
+      "Shell(grep)",
+      "Shell(cat)",
+      "Shell(head)",
+      "Shell(tail)",
+      "Shell(sed)",
+      "Shell(awk)"
+    ],
+    "deny": [
+      "Shell(git)",
+      "Shell(gh)",
+      "Shell(curl)",
+      "Shell(wget)",
+      "Shell(rm)",
+      "Shell(mv)",
+      "Shell(cp)",
+      "Shell(sh)",
+      "Shell(bash)"
+    ]
+  }
+}


### PR DESCRIPTION
## CVE remediation audit (read-only)

**Scanned image:** `ghcr.io/moolen/skouter:1` (99 reported findings)

### Outcome

**No further fixes possible in this rollout** — the harness is configured for **audit-only** and must not modify repository sources. All listed findings remain **open** until maintainers apply code and Dockerfile changes and publish a new image.

### Summary of actions taken

- Read structured inputs from `.patchpilot/input/cve-remediation.json`.
- Confirmed the published container is built from the **repository root** `Dockerfile` via `.github/workflows/ci.yml` (`docker/build-push-action` with `context: .`, `IMAGE_NAME: ghcr.io/moolen/skouter`), matching `Makefile` target `docker.build`.
- Reviewed current `Dockerfile` (`BASEIMAGE` defaults to `golang:1.19`, `RUNIMAGE` to `alpine:3.14`, runtime installs `curl` with `apk`), and `go.mod` (Go 1.19; `golang.org/x/net` v0.5.0; indirect `golang.org/x/oauth2` v0.3.0; `google.golang.org/protobuf` v1.28.1), which aligns with scanner versions (`go1.19.5`, Alpine curl/OpenSSL 1.1.1t-r0, etc.).
- No `go build`, `go test`, or image rebuild was executed as part of this audit-only step.

### Safest remediation plan (for a follow-up non-audit change)

1. **Build/runtime image (`Dockerfile`)** — only file driving the vulnerable published image in CI:
   - **Build stage:** Bump `BASEIMAGE` from `golang:1.19` to a **current patch release** in the same **official `golang` Debian-based** family (e.g. `golang:1.26.x` or `golang:1.25.x`). To clear **all** stdlib-related CVEs in this report (including those whose fixed versions point to **1.25.8+** or **1.26.1+**), choose a single toolchain **at or above the maximum required fixed version** across the listed stdlib issues (the 2025–2026 entries require **≥1.25.8** or **≥1.26.1** on their respective release lines). **Do not guess tags:** list tags from the registry and pick an appropriate patch (e.g. `golang:1.26.*` family) within the same distro family (stay on the Debian-based `golang` image, not switching to Alpine for the compiler stage unless intentionally redesigning the build).
   - **Runtime stage:** Replace `alpine:3.14` with a **supported Alpine** minor release (same **Alpine/musl** family, e.g. 3.20+) so `apk add curl` pulls **curl 8.x** and **OpenSSL 3.x**, addressing `curl`/`libcurl` and **libcrypto/libssl 1.1.1** issues from the obsolete 3.14-era packages. Pin **`apk add`** to specific versions if policy requires (e.g. `curl=...`, `openssl=...` from `apk` index) after verifying versions fix the cited CVEs. Ensure the final `USER` is non-root if you introduce one; current Dockerfile ends without a non-root user — consider adding a dedicated user for production hardening.
   - Rebuild multi-arch images as in CI (`linux/amd64`, `linux/arm64`).

2. **Go module versions (`go.mod` / `go.sum`)** — after setting the Go toolchain:
   - Set `go` directive to match the builder (may require **K8s/controller-runtime** compatibility testing; current deps target Kubernetes **0.26.x**).
   - Raise **`golang.org/x/net`** to at least **v0.38.0** (covers the strictest GHSA in this report for `x/net`; verify with `go mod tidy` and tests).
   - Raise **`golang.org/x/oauth2`** to at least **v0.27.0** (per GHSA-6v2p-p543-phr9).
   - Raise **`google.golang.org/protobuf`** to at least **v1.33.0** (per GHSA-8r3f-844c-mc37).
   - Run **`go mod tidy`**, **`go test ./...`**, and **`govulncheck ./...`**; update **`vendor/`** only if the project vendors dependencies.

3. **Tooling:** If upgrading to **Go 1.26**, align **`golangci-lint`** with a release that supports that Go version (project `Makefile` currently installs **v1.49.0**; consider **v2.9.0+** per golangci-lint release notes for Go 1.26).

4. **CI hygiene:** `.github/workflows/release.yml` references **`./cmd/kubectl-blame`** and an old **Go 1.19.1** tarball — likely copy-paste drift from another project; **human review** is advised so release binaries match **skouter**.

### Fixed findings

_None — this audit did not modify `Dockerfile`, `go.mod`, or other repository sources._

### Findings not remediated (full table)

| CVE ID | Package | File location | Status | Reason |
| --- | --- | --- | --- | --- |
| CVE-2023-44487 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| GHSA-qppj-fm5r-hxr3 | golang.org/x/net | `go.mod`, `go.sum` | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-45288 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| GHSA-4v7x-pqxf-cx7m | golang.org/x/net | `go.mod`, `go.sum` | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2024-24787 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2024-24784 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2024-24791 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2024-24785 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-0464 | libcrypto1.1 | `Dockerfile` (`RUNIMAGE` / runtime `apk` packages) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-0464 | libssl1.1 | `Dockerfile` (`RUNIMAGE` / runtime `apk` packages) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-24538 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-24531 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2024-24783 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-29405 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-45289 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-45290 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-0465 | libcrypto1.1 | `Dockerfile` (`RUNIMAGE` / runtime `apk` packages) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-0465 | libssl1.1 | `Dockerfile` (`RUNIMAGE` / runtime `apk` packages) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-24540 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2024-34156 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| GHSA-vvpx-j8f3-3w6h | golang.org/x/net | `go.mod`, `go.sum` | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2022-41723 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-29406 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| GHSA-8r3f-844c-mc37 | google.golang.org/protobuf | `go.mod`, `go.sum` | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2024-24790 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-22871 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-27533 | curl | `Dockerfile` (`RUNIMAGE` / runtime `apk` packages) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-27533 | libcurl | `Dockerfile` (`RUNIMAGE` / runtime `apk` packages) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-45287 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2024-34158 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-29402 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-23914 | curl | `Dockerfile` (`RUNIMAGE` / runtime `apk` packages) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-23914 | libcurl | `Dockerfile` (`RUNIMAGE` / runtime `apk` packages) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| GHSA-4374-p667-p6c8 | golang.org/x/net | `go.mod`, `go.sum` | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-24534 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| GHSA-6v2p-p543-phr9 | golang.org/x/oauth2 | `go.mod`, `go.sum` | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2024-45336 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-29404 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2024-45341 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-39326 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| GHSA-vvgc-356p-c3xw | golang.org/x/net | `go.mod`, `go.sum` | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-29409 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| GHSA-2wrh-6pvc-2jm9 | golang.org/x/net | `go.mod`, `go.sum` | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-23916 | curl | `Dockerfile` (`RUNIMAGE` / runtime `apk` packages) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-23916 | libcurl | `Dockerfile` (`RUNIMAGE` / runtime `apk` packages) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-39318 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-39319 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-24536 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-27534 | curl | `Dockerfile` (`RUNIMAGE` / runtime `apk` packages) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-27534 | libcurl | `Dockerfile` (`RUNIMAGE` / runtime `apk` packages) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-24539 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2022-41725 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-39323 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-45285 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2024-34155 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-29400 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-27535 | curl | `Dockerfile` (`RUNIMAGE` / runtime `apk` packages) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-27535 | libcurl | `Dockerfile` (`RUNIMAGE` / runtime `apk` packages) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-23915 | curl | `Dockerfile` (`RUNIMAGE` / runtime `apk` packages) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-23915 | libcurl | `Dockerfile` (`RUNIMAGE` / runtime `apk` packages) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-27537 | curl | `Dockerfile` (`RUNIMAGE` / runtime `apk` packages) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-27537 | libcurl | `Dockerfile` (`RUNIMAGE` / runtime `apk` packages) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-61726 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2026-25679 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-61725 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-61723 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-61729 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-47906 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-68121 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2022-41724 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-58186 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-24532 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-61728 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-4673 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| GHSA-qxp5-gwg8-xv66 | golang.org/x/net | `go.mod`, `go.sum` | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-58185 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-47912 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-22866 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-24537 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-58187 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-47907 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-27538 | curl | `Dockerfile` (`RUNIMAGE` / runtime `apk` packages) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-27538 | libcurl | `Dockerfile` (`RUNIMAGE` / runtime `apk` packages) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-61724 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-29403 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-61731 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-61727 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2026-27142 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-27536 | curl | `Dockerfile` (`RUNIMAGE` / runtime `apk` packages) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2023-27536 | libcurl | `Dockerfile` (`RUNIMAGE` / runtime `apk` packages) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-58183 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-61732 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-58189 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-58188 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-61730 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-4674 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2024-24789 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2026-27139 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |
| CVE-2025-22873 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `go.mod` (`go` directive) | Not remediated | Not changed in this audit rollout; apply the remediation plan below when modifying the repository. |

### Validation steps performed

- Repository file review: `.patchpilot/input/cve-remediation.json`, `Dockerfile`, `go.mod`, `.github/workflows/ci.yml`, `Makefile`, `.github/workflows/release.yml` (read-only).
- No compilation, tests, or container builds were run in this audit-only pass.

<!-- patchpilot agent notes -->
# Notes

- **What worked well:** Clear linkage from CI (`IMAGE_NAME` + root `Dockerfile`) to the scanned image; `go.mod` and `Dockerfile` versions explain the scanner’s `go1.19.5`, Alpine curl, and OpenSSL 1.1 findings.
- **What was difficult:** Consolidating many overlapping stdlib CVEs into one coherent minimum Go version; 2025–2026 CVEs push the floor to **Go 1.25.8+ / 1.26.1+**, which may force major dependency upgrades (Kubernetes client stack) — needs maintainer testing outside audit mode.
- **Missing tooling or context:** Registry tag listing (cannot select exact `golang`/`alpine` patch tags without `docker`/`crane`/`aws` access here); full `go test`/`govulncheck` after upgrades; confirmation whether `ghcr.io/moolen/skouter:1` maps to a specific git tag or floating tag.

<!-- patchpilot agent notes end -->

Human intervention requested by agent: true

## Agent Logs

<details>
<summary>cve-remediation stdout</summary>

```text
Audit-only work is done. The harness forbids changing anything except `.patchpilot/output.json`, so **`human_intervention_needed` is `true`** and the write-up is in **`.patchpilot/output.json`**.

### What was verified

- **`ghcr.io/moolen/skouter`** is built from the **root `Dockerfile`** in **`.github/workflows/ci.yml`** (`docker/build-push-action`, `context: .`, `IMAGE_NAME: ghcr.io/moolen/skouter`), consistent with **`make docker.build`**.
- That **`Dockerfile`** uses **`golang:1.19`** (build) and **`alpine:3.14`** + **`apk add curl`** (runtime), matching the scan (`go1.19.5`, old **curl** / **OpenSSL 1.1**).
- **`go.mod`** matches the Go module issues: **`golang.org/x/net` v0.5.0**, indirect **`golang.org/x/oauth2` v0.3.0**, **`google.golang.org/protobuf` v1.28.1**.

### What’s in `output.json`

- **`pr_summary`**: outcome (**audit-only, nothing remediated in-repo**), actions taken, **safest follow-up plan** (bump **`BASEIMAGE`** / **`RUNIMAGE`**, raise **`x/net`**, **`oauth2`**, **`protobuf`**, tooling/CI notes), **Fixed findings: none**, **full 99-row table** (CVE ID, package, file location, status, reason), validation notes, and the **Notes** block in the required HTML comment wrappers.
- **`human_intervention_needed`**: **`true`** (required for this rollout and for real fixes + registry tag selection + possible **Kubernetes** dependency upgrades).
```
</details>