### PR TITLE
PatchPilot: remediate CVEs

### DIFF
--- a/.cursor/cli.json
+++ b/.cursor/cli.json
@@ -1,0 +1,28 @@
+{
+  "permissions": {
+    "allow": [
+      "Read(**)",
+      "Write(.patchpilot/output.json)",
+      "Shell(ls)",
+      "Shell(find)",
+      "Shell(rg)",
+      "Shell(grep)",
+      "Shell(cat)",
+      "Shell(head)",
+      "Shell(tail)",
+      "Shell(sed)",
+      "Shell(awk)"
+    ],
+    "deny": [
+      "Shell(git)",
+      "Shell(gh)",
+      "Shell(curl)",
+      "Shell(wget)",
+      "Shell(rm)",
+      "Shell(mv)",
+      "Shell(cp)",
+      "Shell(sh)",
+      "Shell(bash)"
+    ]
+  }
+}


### PR DESCRIPTION
## CVE audit outcome (moolen/skouter)

**Outcome:** **No remediation applied** in this rollout. The harness ran in **audit-only** mode: only `.patchpilot/output.json` may be changed, so Dockerfile, `go.mod`, and CI were not updated.

**Human intervention is required** to apply the changes below, validate Kubernetes/client-go compatibility after major Go bumps, and re-scan the rebuilt image.

---

## Evidence: which build produces `ghcr.io/moolen/skouter`

- **CI workflow:** `.github/workflows/ci.yml` runs `docker/build-push-action` with `context: .` and pushes `IMAGE_NAME:ghcr.io/moolen/skouter` with a computed tag.
- **Root `Dockerfile`** is therefore the authoritative definition for the published container (not the release workflow, which re-tags `:main` for semver and builds unrelated Go binaries).

Current multi-stage layout:

- **Build stage:** `ARG BASEIMAGE=golang:1.19` (Debian-based; `apt` installs `llvm`/`clang`).
- **Runtime stage:** `ARG RUNIMAGE=alpine:3.14` then `apk add curl`.

The scanner-reported versions (`go1.19.5`, Alpine `curl` 7.79.1-r4, OpenSSL 1.1.1t-r0) match this **stale toolchain and Alpine 3.14** baseline.

---

## Fixed findings

_None — audit-only; no repository files were modified._

---

## Recommended remediation plan (safest effective path)

Apply the **smallest set of changes that clears the scanner** after one coherent upgrade, rather than incremental one-CVE bumps.

### 1) Go standard library (bulk of findings)

- **Target:** Upgrade the **builder** `BASEIMAGE` to a **current Go patch** that satisfies the **highest** fixed version among reported stdlib CVEs (notably recent entries pointing at **Go 1.25.8 / 1.26.1**). Concretely, pick **Go 1.26.1+** (or the newest **1.26.x** / **1.25.x** patch listed in Docker Hub for the same distro family) so a single bump addresses the long tail of stdlib CVEs.
- **Stay in family:** Keep a **Debian-bookworm (or current default)**-style `golang` image if you continue using `apt` in the build stage; do not switch the build stage to Alpine unless you intentionally port `llvm`/`clang` installation.
- **Repository alignment:** Update `go` directive in `go.mod`, run `go mod tidy`, and expect **large indirect updates**; **Kubernetes** deps (`k8s.io/*`, `controller-runtime`) may need coordinated minor/major bumps — treat this as a **compatibility project**, not a one-line edit.

### 2) Alpine runtime (curl, OpenSSL 1.1)

- **Target:** Replace **`alpine:3.14`** (EOL) with a **supported** Alpine (e.g. **3.20+**) so `apk add curl` pulls **modern curl** and **OpenSSL 3.x**, addressing libcrypto/libssl 1.1.1 and curl CVEs without fragile per-package pins on obsolete indexes.
- **Process:** **List tags** from the registry (`docker` Hub for `library/alpine`, or your mirror), select a **specific** tag, then re-scan. Avoid guessing tags.
- **Non-root:** If you introduce a non-root `USER`, keep the final stage non-root after package installs (current Dockerfile runs as root).

### 3) Go modules (direct/indirect)

From the scan and `go.mod`, plan minimum bumps (then resolve to latest compatible with your chosen Go/K8s stack):

| Module | Reported | Direction |
|--------|----------|-----------|
| `golang.org/x/net` | v0.5.0 | Raise to **≥ 0.38.0** (covers multiple GHSA rows; verify with `go mod graph` / govulncheck) |
| `google.golang.org/protobuf` | v1.28.1 | Raise to **≥ 1.33.0** |
| `golang.org/x/oauth2` | v0.3.0 | Raise to **≥ 0.27.0** |

Run **`go mod tidy`**, and **`govulncheck ./...`** after dependency resolution.

### 4) Tooling / CI

- **golangci-lint:** `Makefile` pins **v1.49.0**; after a large Go upgrade, align with a **golangci-lint** release that supports your Go version (project notes: v2.4.0+ for Go 1.25, v2.9.0+ for Go 1.26 — pick a concrete release from upstream releases).
- Re-run **`make generate`** / **`make build`** in CI parity with Dockerfile (`make build` runs code generation).

### 5) Validation before release

- `make build` (or Docker build) locally or in CI.
- `go test` / integration tests as applicable.
- Re-scan **`ghcr.io/moolen/skouter:<new-tag>`** after push.

---

## Unfixed findings (full table)

| CVE ID | Package | File location | Status | Reason |
|--------|---------|---------------|--------|--------|
| CVE-2023-44487 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| GHSA-qppj-fm5r-hxr3 | golang.org/x/net | go.mod, go.sum | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-45288 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| GHSA-4v7x-pqxf-cx7m | golang.org/x/net | go.mod, go.sum | Not remediated | Audit-only rollout; repository not modified |
| CVE-2024-24787 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2024-24784 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2024-24791 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2024-24785 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-0464 | libcrypto1.1 | Dockerfile (RUNIMAGE, apk add curl) | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-0464 | libssl1.1 | Dockerfile (RUNIMAGE, apk add curl) | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-24538 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-24531 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2024-24783 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-29405 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-45289 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-45290 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-0465 | libcrypto1.1 | Dockerfile (RUNIMAGE, apk add curl) | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-0465 | libssl1.1 | Dockerfile (RUNIMAGE, apk add curl) | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-24540 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2024-34156 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| GHSA-vvpx-j8f3-3w6h | golang.org/x/net | go.mod, go.sum | Not remediated | Audit-only rollout; repository not modified |
| CVE-2022-41723 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-29406 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| GHSA-8r3f-844c-mc37 | google.golang.org/protobuf | go.mod, go.sum | Not remediated | Audit-only rollout; repository not modified |
| CVE-2024-24790 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-22871 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-27533 | curl | Dockerfile (RUNIMAGE, apk add curl) | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-27533 | libcurl | Dockerfile (RUNIMAGE, apk add curl) | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-45287 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2024-34158 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-29402 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-23914 | curl | Dockerfile (RUNIMAGE, apk add curl) | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-23914 | libcurl | Dockerfile (RUNIMAGE, apk add curl) | Not remediated | Audit-only rollout; repository not modified |
| GHSA-4374-p667-p6c8 | golang.org/x/net | go.mod, go.sum | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-24534 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| GHSA-6v2p-p543-phr9 | golang.org/x/oauth2 | go.mod, go.sum | Not remediated | Audit-only rollout; repository not modified |
| CVE-2024-45336 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-29404 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2024-45341 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-39326 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| GHSA-vvgc-356p-c3xw | golang.org/x/net | go.mod, go.sum | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-29409 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| GHSA-2wrh-6pvc-2jm9 | golang.org/x/net | go.mod, go.sum | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-23916 | curl | Dockerfile (RUNIMAGE, apk add curl) | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-23916 | libcurl | Dockerfile (RUNIMAGE, apk add curl) | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-39318 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-39319 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-24536 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-27534 | curl | Dockerfile (RUNIMAGE, apk add curl) | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-27534 | libcurl | Dockerfile (RUNIMAGE, apk add curl) | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-24539 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2022-41725 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-39323 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-45285 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2024-34155 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-29400 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-27535 | curl | Dockerfile (RUNIMAGE, apk add curl) | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-27535 | libcurl | Dockerfile (RUNIMAGE, apk add curl) | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-23915 | curl | Dockerfile (RUNIMAGE, apk add curl) | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-23915 | libcurl | Dockerfile (RUNIMAGE, apk add curl) | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-27537 | curl | Dockerfile (RUNIMAGE, apk add curl) | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-27537 | libcurl | Dockerfile (RUNIMAGE, apk add curl) | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-61726 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2026-25679 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-61725 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-61723 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-61729 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-47906 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-68121 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2022-41724 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-58186 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-24532 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-61728 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-4673 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| GHSA-qxp5-gwg8-xv66 | golang.org/x/net | go.mod, go.sum | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-58185 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-47912 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-22866 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-24537 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-58187 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-47907 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-27538 | curl | Dockerfile (RUNIMAGE, apk add curl) | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-27538 | libcurl | Dockerfile (RUNIMAGE, apk add curl) | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-61724 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-29403 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-61731 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-61727 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2026-27142 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-27536 | curl | Dockerfile (RUNIMAGE, apk add curl) | Not remediated | Audit-only rollout; repository not modified |
| CVE-2023-27536 | libcurl | Dockerfile (RUNIMAGE, apk add curl) | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-58183 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-61732 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-58189 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-58188 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-61730 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-4674 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2024-24789 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2026-27139 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |
| CVE-2025-22873 | stdlib | Dockerfile (BASEIMAGE), go.mod | Not remediated | Audit-only rollout; repository not modified |

---

## Actions taken in this audit

- Read `.patchpilot/input/cve-remediation.json` and mapped findings to the repository layout.
- Confirmed the published image is built from the **repository root `Dockerfile`** via `.github/workflows/ci.yml` (`docker/build-push-action`, context `.`).
- Reviewed `go.mod`, `Makefile`, and workflows for upgrade blast radius (Kubernetes client stack, code generation, lint pin).
- Attempted `go build` without codegen: build **failed** on undefined BPF symbols (`pkg/bpf/bpf.go`), consistent with **`make build` requiring `make generate`** first — not attributed to CVE work.

## Validation steps performed

- Inspected CI/release workflows and `Dockerfile`/`go.mod`.
- Ran `go version` (environment: **go1.26.1**).
- Ran `go build -o /tmp/skouter-test .` **without** `make generate` — **failed** with missing generated BPF types (`bpfObjects`, `loadBpf`, etc.). Use `make build` per `Makefile` for a real compile check.

<!-- patchpilot agent notes -->
# Notes

- **What worked well:** The repository has a single obvious image pipeline (`ci.yml` + root `Dockerfile`); mapping scanner packages to **builder Go**, **Alpine runtime**, and **go.mod** modules is straightforward.
- **What was difficult:** **99** scanner rows collapse to a few **root causes**, but fixing them **safely** still implies a **large Go + Kubernetes dependency migration** and regenerated artifacts — too risky to do blind in one shot without interactive testing.
- **Missing tooling / context:** Registry tag listing (Docker Hub / mirrors) was not executed here; **human** choice of exact `golang` and `alpine` tags after `list` operations. Full validation needs **`make generate`** and possibly **`clang`/`llvm`** in the build environment. A post-fix **image re-scan** report would confirm remediation.
<!-- patchpilot agent notes end -->

Human intervention requested by agent: true

## Agent Logs

<details>
<summary>cve-remediation stdout</summary>

```text
Audit-only work is done. Summary:

## Result

- **Wrote** `.patchpilot/output.json` with `human_intervention_needed: true` and a full `pr_summary`.
- **No other repo files** were changed (per audit-only rules).

## Findings from the repo

- **`ghcr.io/moolen/skouter`** is built by **`.github/workflows/ci.yml`** (`docker/build-push-action`, context `.`) → **root `Dockerfile`**.
- **`Dockerfile`:** `golang:1.19` build stage + **`alpine:3.14`** runtime with `apk add curl` — matches the scan (`go1.19.5`, old curl/OpenSSL 1.1).
- **`go.mod`** pins old **`golang.org/x/net`**, **`protobuf`**, **`oauth2`** aligned with the report.

The `pr_summary` includes: fixed findings (none), a **recommended remediation plan** (Go bump, Alpine bump, module bumps, CI/lint/govulncheck), a **99-row table** of unfixed findings, actions taken, validation notes, and the required **Notes** block in `<!-- patchpilot agent notes -->` … `<!-- patchpilot agent notes end -->`.
```
</details>