### PR TITLE
PatchPilot: remediate CVEs

### DIFF
--- a/.cursor/cli.json
+++ b/.cursor/cli.json
@@ -1,0 +1,28 @@
+{
+  "permissions": {
+    "allow": [
+      "Read(**)",
+      "Write(.patchpilot/output.json)",
+      "Shell(ls)",
+      "Shell(find)",
+      "Shell(rg)",
+      "Shell(grep)",
+      "Shell(cat)",
+      "Shell(head)",
+      "Shell(tail)",
+      "Shell(sed)",
+      "Shell(awk)"
+    ],
+    "deny": [
+      "Shell(git)",
+      "Shell(gh)",
+      "Shell(curl)",
+      "Shell(wget)",
+      "Shell(rm)",
+      "Shell(mv)",
+      "Shell(cp)",
+      "Shell(sh)",
+      "Shell(bash)"
+    ]
+  }
+}


### PR DESCRIPTION
# CVE remediation audit (moolen/skouter)

This rollout was **audit-only**: no repository files were modified. The following describes the **safest remediation approach** for `ghcr.io/moolen/skouter:1` based on repository inspection and the scanner report.

## Image build evidence

- **Published image:** `ghcr.io/moolen/skouter` (report tag `1`).
- **Build definition:** `.github/workflows/ci.yml` builds and pushes the image with `docker/build-push-action` using repository root context (`.`).
- **Dockerfile:** Root `Dockerfile` sets `BASEIMAGE=golang:1.19` (compile stage; Debian-based, `apt` installs `llvm`/`clang`) and `RUNIMAGE=alpine:3.14` (runtime; `apk add curl`). This matches scanner signals: Go **1.19.5** (resolved `golang:1.19` tag) and **Alpine 3.14-era** `curl` / OpenSSL 1.1 packages.
- **Release workflow:** `.github/workflows/release.yml` promotes an existing `:main` tag to the release tag rather than rebuilding from Dockerfile for that job—image freshness still depends on CI builds from `Dockerfile`.

## Safest remediation plan (recommended order)

1. **Go standard library (bulk of findings):** Move the **build** stage to a supported official `golang` image whose Go version satisfies the **highest** fixed-version requirement across reported CVEs (notably **1.26.1** or **1.25.8** lines for 2026 CVEs such as CVE-2026-25679, CVE-2026-27139, CVE-2026-27142). Update the `go` directive in `go.mod` to match. **Do not guess tags:** list tags from the registry (e.g. Docker Hub `golang` tags in the same distro family as today’s build stage) and pick a specific patch release.
2. **Alpine runtime:** Replace **`alpine:3.14`** (EOL) with a **currently supported** Alpine minor (e.g. 3.19+) so `curl`/`libcurl` and OpenSSL are on maintained branches. Pin **`apk add`** to **specific** `curl`/`libcurl` versions that close the listed CVEs if you must avoid unpinned `latest`-equivalent upgrades.
3. **Go modules:** Raise direct/indirect dependencies to at least: **`golang.org/x/net` ≥ 0.38.0** (covers the highest `x/net` GHSA floor in the report), **`golang.org/x/oauth2` ≥ 0.27.0**, **`google.golang.org/protobuf` ≥ 1.33.0**. Run **`go mod tidy`** and resolve any **Kubernetes / controller-runtime** compatibility fallout (likely a **coordinated bump** of `k8s.io/*` and `sigs.k8s.io/controller-runtime`—expect **human review** and CI time).
4. **CI / release:** Align any hard-coded Go download URLs (e.g. `release.yml` **`goversion`**) with the chosen Go version if those steps remain in use; re-validate the **`project_path`** in `release.yml` (it currently references `./cmd/kubectl-blame`, which may be stale relative to this module).
5. **Validation:** After implementation, rebuild the image, run **`go test`**, **`govulncheck ./...`**, and **rescan** the published image.

## Fixed findings

- **None** — audit-only execution; `Dockerfile`, `go.mod`, and workflows were not changed.

## Findings not fixed (full table)

| CVE ID | Package | File location | Status | Reason |
| --- | --- | --- | --- | --- |
| CVE-2023-44487 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| GHSA-qppj-fm5r-hxr3 | golang.org/x/net | `go.mod` / `go.sum` | Open | Requires `golang.org/x/net` ≥0.38.0 (supersedes lower GHSA floors); coordinate with k8s deps; not applied (audit-only). |
| CVE-2023-45288 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| GHSA-4v7x-pqxf-cx7m | golang.org/x/net | `go.mod` / `go.sum` | Open | Requires `golang.org/x/net` ≥0.38.0 (supersedes lower GHSA floors); coordinate with k8s deps; not applied (audit-only). |
| CVE-2024-24787 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2024-24784 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2024-24791 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2024-24785 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2023-0464 | libcrypto1.1 | `Dockerfile` (RUNIMAGE, `apk` packages) | Open | OpenSSL 1.1.1 on Alpine 3.14; upgrade runtime image or pin OpenSSL packages; not applied (audit-only). |
| CVE-2023-0464 | libssl1.1 | `Dockerfile` (RUNIMAGE, `apk` packages) | Open | OpenSSL 1.1.1 on Alpine 3.14; upgrade runtime image or pin OpenSSL packages; not applied (audit-only). |
| CVE-2023-24538 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2023-24531 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2024-24783 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2023-29405 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2023-45289 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2023-45290 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2023-0465 | libcrypto1.1 | `Dockerfile` (RUNIMAGE, `apk` packages) | Open | OpenSSL 1.1.1 on Alpine 3.14; upgrade runtime image or pin OpenSSL packages; not applied (audit-only). |
| CVE-2023-0465 | libssl1.1 | `Dockerfile` (RUNIMAGE, `apk` packages) | Open | OpenSSL 1.1.1 on Alpine 3.14; upgrade runtime image or pin OpenSSL packages; not applied (audit-only). |
| CVE-2023-24540 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2024-34156 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| GHSA-vvpx-j8f3-3w6h | golang.org/x/net | `go.mod` / `go.sum` | Open | Requires `golang.org/x/net` ≥0.38.0 (supersedes lower GHSA floors); coordinate with k8s deps; not applied (audit-only). |
| CVE-2022-41723 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2023-29406 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| GHSA-8r3f-844c-mc37 | google.golang.org/protobuf | `go.mod` / `go.sum` | Open | Requires `google.golang.org/protobuf` ≥1.33.0; not applied (audit-only). |
| CVE-2024-24790 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2025-22871 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2023-27533 | curl | `Dockerfile` (RUNIMAGE, `apk` packages) | Open | Requires upgrading from Alpine 3.14 and installing patched `curl`/`libcurl` (or pinning specific fixed versions); not applied (audit-only). |
| CVE-2023-27533 | libcurl | `Dockerfile` (RUNIMAGE, `apk` packages) | Open | Requires upgrading from Alpine 3.14 and installing patched `curl`/`libcurl` (or pinning specific fixed versions); not applied (audit-only). |
| CVE-2023-45287 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2024-34158 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2023-29402 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2023-23914 | curl | `Dockerfile` (RUNIMAGE, `apk` packages) | Open | Requires upgrading from Alpine 3.14 and installing patched `curl`/`libcurl` (or pinning specific fixed versions); not applied (audit-only). |
| CVE-2023-23914 | libcurl | `Dockerfile` (RUNIMAGE, `apk` packages) | Open | Requires upgrading from Alpine 3.14 and installing patched `curl`/`libcurl` (or pinning specific fixed versions); not applied (audit-only). |
| GHSA-4374-p667-p6c8 | golang.org/x/net | `go.mod` / `go.sum` | Open | Requires `golang.org/x/net` ≥0.38.0 (supersedes lower GHSA floors); coordinate with k8s deps; not applied (audit-only). |
| CVE-2023-24534 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| GHSA-6v2p-p543-phr9 | golang.org/x/oauth2 | `go.mod` / `go.sum` | Open | Requires `golang.org/x/oauth2` ≥0.27.0; not applied (audit-only). |
| CVE-2024-45336 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2023-29404 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2024-45341 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2023-39326 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| GHSA-vvgc-356p-c3xw | golang.org/x/net | `go.mod` / `go.sum` | Open | Requires `golang.org/x/net` ≥0.38.0 (supersedes lower GHSA floors); coordinate with k8s deps; not applied (audit-only). |
| CVE-2023-29409 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| GHSA-2wrh-6pvc-2jm9 | golang.org/x/net | `go.mod` / `go.sum` | Open | Requires `golang.org/x/net` ≥0.38.0 (supersedes lower GHSA floors); coordinate with k8s deps; not applied (audit-only). |
| CVE-2023-23916 | curl | `Dockerfile` (RUNIMAGE, `apk` packages) | Open | Requires upgrading from Alpine 3.14 and installing patched `curl`/`libcurl` (or pinning specific fixed versions); not applied (audit-only). |
| CVE-2023-23916 | libcurl | `Dockerfile` (RUNIMAGE, `apk` packages) | Open | Requires upgrading from Alpine 3.14 and installing patched `curl`/`libcurl` (or pinning specific fixed versions); not applied (audit-only). |
| CVE-2023-39318 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2023-39319 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2023-24536 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2023-27534 | curl | `Dockerfile` (RUNIMAGE, `apk` packages) | Open | Requires upgrading from Alpine 3.14 and installing patched `curl`/`libcurl` (or pinning specific fixed versions); not applied (audit-only). |
| CVE-2023-27534 | libcurl | `Dockerfile` (RUNIMAGE, `apk` packages) | Open | Requires upgrading from Alpine 3.14 and installing patched `curl`/`libcurl` (or pinning specific fixed versions); not applied (audit-only). |
| CVE-2023-24539 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2022-41725 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2023-39323 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2023-45285 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2024-34155 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2023-29400 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2023-27535 | curl | `Dockerfile` (RUNIMAGE, `apk` packages) | Open | Requires upgrading from Alpine 3.14 and installing patched `curl`/`libcurl` (or pinning specific fixed versions); not applied (audit-only). |
| CVE-2023-27535 | libcurl | `Dockerfile` (RUNIMAGE, `apk` packages) | Open | Requires upgrading from Alpine 3.14 and installing patched `curl`/`libcurl` (or pinning specific fixed versions); not applied (audit-only). |
| CVE-2023-23915 | curl | `Dockerfile` (RUNIMAGE, `apk` packages) | Open | Requires upgrading from Alpine 3.14 and installing patched `curl`/`libcurl` (or pinning specific fixed versions); not applied (audit-only). |
| CVE-2023-23915 | libcurl | `Dockerfile` (RUNIMAGE, `apk` packages) | Open | Requires upgrading from Alpine 3.14 and installing patched `curl`/`libcurl` (or pinning specific fixed versions); not applied (audit-only). |
| CVE-2023-27537 | curl | `Dockerfile` (RUNIMAGE, `apk` packages) | Open | Requires upgrading from Alpine 3.14 and installing patched `curl`/`libcurl` (or pinning specific fixed versions); not applied (audit-only). |
| CVE-2023-27537 | libcurl | `Dockerfile` (RUNIMAGE, `apk` packages) | Open | Requires upgrading from Alpine 3.14 and installing patched `curl`/`libcurl` (or pinning specific fixed versions); not applied (audit-only). |
| CVE-2025-61726 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2026-25679 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2025-61725 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2025-61723 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2025-61729 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2025-47906 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2025-68121 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2022-41724 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2025-58186 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2023-24532 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2025-61728 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2025-4673 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| GHSA-qxp5-gwg8-xv66 | golang.org/x/net | `go.mod` / `go.sum` | Open | Requires `golang.org/x/net` ≥0.38.0 (supersedes lower GHSA floors); coordinate with k8s deps; not applied (audit-only). |
| CVE-2025-58185 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2025-47912 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2025-22866 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2023-24537 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2025-58187 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2025-47907 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2023-27538 | curl | `Dockerfile` (RUNIMAGE, `apk` packages) | Open | Requires upgrading from Alpine 3.14 and installing patched `curl`/`libcurl` (or pinning specific fixed versions); not applied (audit-only). |
| CVE-2023-27538 | libcurl | `Dockerfile` (RUNIMAGE, `apk` packages) | Open | Requires upgrading from Alpine 3.14 and installing patched `curl`/`libcurl` (or pinning specific fixed versions); not applied (audit-only). |
| CVE-2025-61724 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2023-29403 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2025-61731 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2025-61727 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2026-27142 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2023-27536 | curl | `Dockerfile` (RUNIMAGE, `apk` packages) | Open | Requires upgrading from Alpine 3.14 and installing patched `curl`/`libcurl` (or pinning specific fixed versions); not applied (audit-only). |
| CVE-2023-27536 | libcurl | `Dockerfile` (RUNIMAGE, `apk` packages) | Open | Requires upgrading from Alpine 3.14 and installing patched `curl`/`libcurl` (or pinning specific fixed versions); not applied (audit-only). |
| CVE-2025-58183 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2025-61732 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2025-58189 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2025-58188 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2025-61730 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2025-4674 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2024-24789 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2026-27139 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |
| CVE-2025-22873 | stdlib | `Dockerfile` (BASEIMAGE), `go.mod` (go directive) | Open | Requires bumping Go toolchain in build image and `go` directive to ≥1.26.1 (or ≥1.25.8 per CVE family); not applied (audit-only). |

## Actions taken (this rollout)

- Reviewed `.patchpilot/input/cve-remediation.json` and mapped findings to `Dockerfile` / `go.mod`.
- Confirmed CI uses root `Dockerfile` for `ghcr.io/moolen/skouter` per `.github/workflows/ci.yml`.
- Recorded host `go version` and attempted a local `go build` (failed: missing generated eBPF symbols in `pkg/bpf`; expected without codegen).

## Outcome

**Partially remediated (plan only).** No patches were applied because this run was audit-only. Addressing all reported items requires a **non-trivial Go upgrade** and **Alpine/runtime refresh**, plus likely **Kubernetes dependency alignment**—appropriate for a **human-led implementation** with registry tag listing and full CI/rescan.

## Validation steps performed

- Read `Dockerfile`, `go.mod`, `.github/workflows/ci.yml`, `.github/workflows/release.yml`.
- Ran `go version` (host toolchain: go1.26.1; module declares `go 1.19`).
- Ran `go build -o /tmp/skouter-build-test .` — **failed** on undefined BPF-generated identifiers in `pkg/bpf` (pre-existing codegen requirement, not CVE-related).

<!-- patchpilot agent notes -->
# Notes

- **What worked well:** CI workflow clearly references `IMAGE_NAME: ghcr.io/moolen/skouter` and root `Dockerfile`; vulnerability sources map cleanly to build-stage Go, runtime Alpine, and module versions.
- **What was difficult:** Large overlap of many CVE rows on the same root causes (stdlib + old Alpine + outdated `x/net`); full table is long but repetitive.
- **Missing tooling/context:** Registry tag listing and image rebuild/rescan were not performed in this audit-only run; access to a maintained tag matrix for `golang` and `alpine` images and a post-change scanner run would confirm remediation.
<!-- patchpilot agent notes end -->

Human intervention requested by agent: true

## Agent Logs

<details>
<summary>cve-remediation stdout</summary>

```text
Audit-only work is done. Summary:

## What was done

- **Only** `.patchpilot/output.json` was written (no other repo files changed).
- **`human_intervention_needed`** is **`true`** as required.
- **`pr_summary`** includes:
  - Evidence that **`ghcr.io/moolen/skouter`** is built from the **root `Dockerfile`** via **`.github/workflows/ci.yml`** (`docker/build-push-action`, context `.`).
  - A **remediation plan**: bump **`BASEIMAGE`** (`golang:1.19` → modern Go, e.g. **≥1.26.1** / **≥1.25.8** for the 2026 stdlib CVEs), refresh **`RUNIMAGE`** (**`alpine:3.14`** → supported Alpine), update **`golang.org/x/net` (≥0.38.0)**, **`golang.org/x/oauth2` (≥0.27.0)**, **`google.golang.org/protobuf` (≥1.33.0)**, plus CI/release notes (`release.yml` Go URL / `project_path`).
  - **Fixed findings:** none (audit-only).
  - **Full table** of all **99** open findings with CVE, package, file location, status, reason.
  - **Outcome:** partially remediated (plan only).
  - **Validation:** file review; `go version`; `go build` failed on missing eBPF codegen in `pkg/bpf` (pre-existing).
  - **Notes** inside `<!-- patchpilot agent notes -->` … `<!-- patchpilot agent notes end -->`.

Result path: `.patchpilot/output.json`.
```
</details>